### PR TITLE
Update autopep8 to 1.5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-autopep8==1.5.1
+autopep8==1.5.4


### PR DESCRIPTION
Python 3.8 isn't supported in autopep8 1.5.1 out of the box, because it uses an older version of pycodestyle.
See hhatto/autopep8#507.