### PR TITLE
Fix evaluation in if-clause in Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The action outputs the exit code from autopep8. This can be useful in combinatio
 
 ```yml
       - name: Fail if autopep8 made changes
-        if: steps.autopep8.outputs.exit-code == 2
+        if: ${{ steps.autopep8.outputs.exit-code == 2 }}
         run: exit 1
 ```
 


### PR DESCRIPTION
Following syntax from https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsif

I tried to run a similar case without the `${{ ... }}` as suggested in the original example, but the `if` never evaluated `true`. I'm not very experienced with github actions. Therefore, if this is not a obvious case, I can also provide an example.